### PR TITLE
Remove defaultProps causing warning, no longer supported/needed

### DIFF
--- a/packages/webshell/src/hooks/useWebshell.ts
+++ b/packages/webshell/src/hooks/useWebshell.ts
@@ -148,11 +148,6 @@ export interface UseWebshellParams<
   webViewRef?: ElementRef<any>;
 }
 
-const defaultProps = {
-  webshellDebug: __DEV__,
-  webshellStrictMode: false
-};
-
 /**
  * Inject features into a `WebView`, enabling capabilities such
  * as:
@@ -219,8 +214,8 @@ export default function useWebshell<
   const {
     webHandleRef,
     injectedJavaScript: userInjectedJavaScript,
-    webshellDebug = defaultProps.webshellDebug,
-    webshellStrictMode = defaultProps.webshellStrictMode,
+    webshellDebug = __DEV__,
+    webshellStrictMode = false,
     ...props
   } = webshellProps;
   const reporter = React.useMemo(

--- a/packages/webshell/src/makeWebshell.tsx
+++ b/packages/webshell/src/makeWebshell.tsx
@@ -8,11 +8,6 @@ import type {
 } from './types';
 import useWebshell from './hooks/useWebshell';
 
-const defaultProps = {
-  webshellDebug: __DEV__,
-  webshellStrictMode: false
-};
-
 /**
  * Creates a React component which decorates `WebView` component with additional
  * capabilities such as:
@@ -62,7 +57,6 @@ export default function makeWebshell<
     const webViewProps = useWebshell({ features, props, webViewRef });
     return React.createElement(WebView, webViewProps);
   };
-  Webshell.defaultProps = defaultProps;
   return React.forwardRef<
     ElementRef<C>,
     WebshellProps<ComponentPropsWithRef<C>, F>


### PR DESCRIPTION
Using defaultProps, triggers a warning in the Simulator, since it has been phased out.

_One API that has long overstayed its welcome is defaultProps–the old school way of declaratively specifying default values for a component’s props. It’s ancient, covered in cobwebs, and no longer relevant within the context of today’s JavaScript ecosystem. At one point it was incredibly valuable to have, but now it’s time to give it up._
~Sophia

...read more: https://sophiabits.com/blog/stop-using-defaultprops

P.S. Do you want me to do the version bump, or is that automated?